### PR TITLE
private -> friend

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 use crate::parse::err::*;
 use rq_engine::{
     command::{img_store::GroupImageStoreResp, long_conn::OffPicUpResp},
-    msg::elem::{PrivateImage, GroupImage},
-    structs::{GroupMessage, MessageReceipt, PrivateMessage},
+    msg::elem::{FriendImage, GroupImage},
+    structs::{GroupMessage, MessageReceipt, FriendMessage},
     RQResult,
 };
 use rs_qq::{structs::ImageInfo, Client};
@@ -122,7 +122,7 @@ impl MessageId for SPrivateMessage {
 }
 
 impl SPrivateMessage {
-    pub fn new(m: PrivateMessage, message: Message) -> Self {
+    pub fn new(m: FriendMessage, message: Message) -> Self {
         Self {
             seqs: m.seqs,
             rands: m.rands,
@@ -244,10 +244,10 @@ impl SImage {
         }
     }
 
-    pub async fn try_into_private_elem(self, cli: &Client, target: i64) -> WQResult<PrivateImage> {
+    pub async fn try_into_private_elem(self, cli: &Client, target: i64) -> WQResult<FriendImage> {
         let info: ImageInfo = self.into();
-        match cli.get_private_image_store(target, &info).await? {
-            OffPicUpResp::Exist(image_id) => Ok(info.into_private_image(image_id)),
+        match cli.get_off_pic_store(target, &info).await? {
+            OffPicUpResp::Exist(image_id) => Ok(info.into_friend_image(image_id)),
             _ => Err(WQError::image_not_exist()),
         }
     }

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -170,7 +170,7 @@ impl Handler {
                         .await?;
                 let receipt = self
                     .0
-                    .send_private_message(target, chain)
+                    .send_friend_message(target, chain)
                     .await
                     .map_err(rqerror_to_resps)?;
                 let message_id = receipt.seqs[0].to_string();
@@ -202,7 +202,7 @@ impl Handler {
                 match m {
                     SMessage::Private(p) => {
                         self.0
-                            .recall_private_message(p.from_uin, p.time as i64, p.seqs, p.rands)
+                            .recall_friend_message(p.from_uin, p.time as i64, p.seqs, p.rands)
                             .await
                             .map_err(rqerror_to_resps)?;
                     }

--- a/src/parse/event.rs
+++ b/src/parse/event.rs
@@ -16,7 +16,7 @@ pub async fn qevent2event(ob: &walle_core::impls::OneBot, event: QEvent) -> Opti
         }
 
         // message
-        QEvent::PrivateMessage(pme) => {
+        QEvent::FriendMessage(pme) => {
             let message = super::msg_chain2msg_seg_vec(pme.message.elements.clone());
             let event = ob
                 .new_event(


### PR DESCRIPTION
修改rs-qq private->friend，为临时消息做准备

TODO:
支持 群临时消息(grp_tmp)、WPA临时消息(wpa_tmp)
支持 主动发送群临时消息
可能需要修改 `user_id = "member:{group_code}:{user_id}"`、`user_id = "wpa:{user_id}:{sig_base64}"`