### PR TITLE
ricq 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,9 +936,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
  "http",
@@ -1033,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown 0.11.2",
@@ -1076,9 +1076,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "jcers"
@@ -1133,9 +1133,9 @@ checksum = "7efd1d698db0759e6ef11a7cd44407407399a910c774dd804c64c032da7826ff"
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "linked-hash-map"
@@ -1305,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "7b10983b38c53aebdf33f542c6275b0f58a238129d00c4ae0e6fb59738d783ca"
 
 [[package]]
 name = "opaque-debug"
@@ -1349,9 +1349,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.18.0+1.1.1n"
+version = "111.20.0+1.1.1o"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7897a926e1e8d00219127dc020130eca4292e5ca666dd592480d72c3eca2ff6c"
+checksum = "92892c4f87d56e376e469ace79f1128fdaded07646ddf73aa0be4706ff712dec"
 dependencies = [
  "cc",
 ]
@@ -1372,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+checksum = "029d8d0b2f198229de29dca79676f2738ff952edf3fde542eb8bf94d8c21b435"
 
 [[package]]
 name = "p256"
@@ -1450,9 +1450,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "petgraph"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+checksum = "51b305cc4569dd4e8765bab46261f67ef5d4d11a4b6e745100ee5dad8948b46c"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -1551,11 +1551,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1693,9 +1693,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -1705,9 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -1726,9 +1726,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1737,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "remove_dir_all"
@@ -1763,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "ricq"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1f05cbc4e0a4309cbc216b79cdeb93a83753e52333ec55df4d41ab4c761dcf"
+checksum = "d380f7c0f6cfcb46f3f0827f62424f1bbb969e180030621289da8fb999fe575a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1789,9 +1789,9 @@ dependencies = [
 
 [[package]]
 name = "ricq-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fed96769387c4ea56166dfc79850127c544cc8708c04b874806f810640a0ca7"
+checksum = "66e3c43ef45bdf6ab28f9d2b05ad5338ef4047a20a43495b67b503ecc0882328"
 dependencies = [
  "byteorder",
  "bytes",
@@ -1849,18 +1849,18 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "schannel"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2083,13 +2083,13 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07e33e919ebcd69113d5be0e4d70c5707004ff45188910106854f38b960df4a"
+checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2268,9 +2268,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2394,6 +2394,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2407,12 +2413,6 @@ name = "unicode-segmentation"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "uri-reader"

--- a/src/database/image.rs
+++ b/src/database/image.rs
@@ -15,10 +15,10 @@ pub async fn save_image(data: &[u8]) -> WQResult<ImageInfo> {
     let info = ImageInfo::try_new(data).map_err(|_| WQError::image_info_decode_error())?;
     let mut file = tokio::fs::File::create(&info.path())
         .await
-        .map_err(|e| WQError::file_create_error(e))?;
+        .map_err(WQError::file_create_error)?;
     file.write_all(data.as_ref())
         .await
-        .map_err(|e| WQError::file_write_error(e))?;
+        .map_err(WQError::file_write_error)?;
     Ok(info)
 }
 

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -150,7 +150,7 @@ impl Handler {
 
     async fn send_message(&self, c: SendMessage, ob: &OneBot) -> WQResult<Resps> {
         if &c.detail_type == "group" {
-            let group_id = c.group_id.ok_or(WQError::bad_param("group_id"))?;
+            let group_id = c.group_id.ok_or_else(|| WQError::bad_param("group_id"))?;
             let group_code = group_id
                 .parse()
                 .map_err(|_| WQError::bad_param("group_id"))?;
@@ -191,7 +191,7 @@ impl Handler {
                 Err(WQError::empty_message())
             }
         } else if &c.detail_type == "private" {
-            let target_id = c.user_id.ok_or(WQError::bad_param("user_id"))?;
+            let target_id = c.user_id.ok_or_else(|| WQError::bad_param("user_id"))?;
             let target = target_id
                 .parse()
                 .map_err(|_| WQError::bad_param("user_id"))?;
@@ -325,11 +325,11 @@ impl Handler {
             .get_group_info(group_id)
             .await
             .map_err(WQError::RQ)?
-            .ok_or_else(|| WQError::group_not_exist())?;
+            .ok_or_else(WQError::group_not_exist)?;
         Ok(Resps::success(
             GroupInfoContent {
                 group_id: info.uin.to_string(),
-                group_name: info.name.to_string(),
+                group_name: info.name,
             }
             .into(),
         ))
@@ -359,7 +359,7 @@ impl Handler {
             .get_group_info(group_id)
             .await
             .map_err(WQError::RQ)?
-            .ok_or_else(|| WQError::group_not_exist())?;
+            .ok_or_else(WQError::group_not_exist)?;
 
         let v = self
             .0
@@ -391,7 +391,7 @@ impl Handler {
         Ok(Resps::success(
             UserInfoContent {
                 user_id: member.uin.to_string(),
-                nickname: member.nickname.clone(),
+                nickname: member.nickname,
             }
             .into(),
         ))

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -1,9 +1,7 @@
-use crate::database::{Database, SGroupMessage, SMessage, SPrivateMessage, WQDatabase};
-use crate::error::{WQError, WQResult};
-use crate::parse::MsgChainBuilder;
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use cached::SizedCache;
-use std::sync::Arc;
 use tokio::sync::Mutex;
 use walle_core::action::{
     DeleteMessage, GetGroupInfo, GetGroupMemberInfo, GetGroupMemberList, GetLatestEvents,
@@ -17,6 +15,10 @@ use walle_core::{
     ActionHandler, ColoredAlt, RespContent, Resps, StandardAction, StandardEvent,
 };
 use walle_core::{ExtendedMap, MessageContent};
+
+use crate::database::{Database, SGroupMessage, SMessage, SPrivateMessage, WQDatabase};
+use crate::error::{WQError, WQResult};
+use crate::parse::MsgChainBuilder;
 
 mod file;
 pub(crate) mod v11;
@@ -287,13 +289,13 @@ impl Handler {
             .map_err(|_| WQError::bad_param("user_id"))?;
         let info = self
             .0
-            .find_friend(user_id)
+            .get_summary_info(user_id)
             .await
-            .ok_or_else(|| WQError::friend_not_exist())?;
+            .map_err(WQError::RQ)?;
         Ok(Resps::success(
             UserInfoContent {
                 user_id: info.uin.to_string(),
-                nickname: info.nick.to_string(),
+                nickname: info.nickname,
             }
             .into(),
         ))
@@ -301,13 +303,13 @@ impl Handler {
     async fn get_friend_list(&self) -> WQResult<Resps> {
         Ok(Resps::success(
             self.0
-                .friends
-                .read()
+                .get_friend_list()
                 .await
+                .map_err(WQError::RQ)?
                 .iter()
                 .map(|i| UserInfoContent {
-                    user_id: i.0.to_string(),
-                    nickname: i.1.nick.to_string(),
+                    user_id: i.uin.to_string(),
+                    nickname: i.nick.to_string(),
                 })
                 .collect::<Vec<_>>()
                 .into(),
@@ -320,13 +322,14 @@ impl Handler {
             .map_err(|_| WQError::bad_param("group_id"))?;
         let info = self
             .0
-            .find_group(group_id, true)
+            .get_group_info(group_id)
             .await
+            .map_err(WQError::RQ)?
             .ok_or_else(|| WQError::group_not_exist())?;
         Ok(Resps::success(
             GroupInfoContent {
-                group_id: info.info.uin.to_string(),
-                group_name: info.info.name.to_string(),
+                group_id: info.uin.to_string(),
+                group_name: info.name.to_string(),
             }
             .into(),
         ))
@@ -334,13 +337,13 @@ impl Handler {
     async fn get_group_list(&self) -> WQResult<Resps> {
         Ok(Resps::success(
             self.0
-                .groups
-                .read()
+                .get_group_list()
                 .await
-                .iter()
+                .map_err(WQError::RQ)?
+                .into_iter()
                 .map(|i| GroupInfoContent {
-                    group_id: i.0.to_string(),
-                    group_name: i.1.info.name.clone(),
+                    group_id: i.code.to_string(),
+                    group_name: i.name,
                 })
                 .collect::<Vec<_>>()
                 .into(),
@@ -353,13 +356,16 @@ impl Handler {
             .map_err(|_| WQError::bad_param("group_id"))?;
         let group = self
             .0
-            .find_group(group_id, true)
+            .get_group_info(group_id)
             .await
+            .map_err(WQError::RQ)?
             .ok_or_else(|| WQError::group_not_exist())?;
-        let v = group
-            .members
-            .read()
+
+        let v = self
+            .0
+            .get_group_member_list(group_id, group.owner_uin)
             .await
+            .map_err(WQError::RQ)?
             .iter()
             .map(|i| UserInfoContent {
                 user_id: i.uin.to_string(),
@@ -377,24 +383,18 @@ impl Handler {
             .user_id
             .parse()
             .map_err(|_| WQError::bad_param("user_id"))?;
-        let group = self
+        let member = self
             .0
-            .find_group(group_id, true)
+            .get_group_member_info(group_id, uin)
             .await
-            .ok_or_else(|| WQError::group_not_exist())?;
-        let list = group.members.read().await;
-        let v: Vec<_> = list.iter().filter(|i| i.uin == uin).collect();
-        if v.is_empty() {
-            Err(WQError::group_member_not_exist())
-        } else {
-            Ok(Resps::success(
-                UserInfoContent {
-                    user_id: v[0].uin.to_string(),
-                    nickname: v[0].nickname.clone(),
-                }
-                .into(),
-            ))
-        }
+            .map_err(WQError::RQ)?;
+        Ok(Resps::success(
+            UserInfoContent {
+                user_id: member.uin.to_string(),
+                nickname: member.nickname.clone(),
+            }
+            .into(),
+        ))
     }
     async fn set_group_name(&self, c: SetGroupName, _ob: &OneBot) -> WQResult<Resps> {
         self.0

--- a/src/login.rs
+++ b/src/login.rs
@@ -51,8 +51,7 @@ pub(crate) async fn login(cli: &Arc<Client>, config: &crate::config::QQConfig) -
         cli.register_client().await?;
     }
     after_login(cli).await;
-    cli.reload_friends().await?;
-    cli.reload_groups(1024).await
+    Ok(())
 }
 
 pub(crate) async fn start_reconnect(cli: &Arc<Client>, config: &crate::config::QQConfig) {


### PR DESCRIPTION
- 更新到 ricq 0.1.4
- get_user_info 改为获取陌生人信息（之前是获取好友信息）
- get_friend_list、get_group_info、get_group_list、get_group_member_info 改为直接调用 API，更准确，性能基本无影响
- 修复 at display