### PR TITLE
ci: improve deploy-doc workflow

### DIFF
--- a/.github/workflows/deploy-doc.yaml
+++ b/.github/workflows/deploy-doc.yaml
@@ -41,3 +41,7 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./doc/book
+        cname: walle-q.1bot.dev
+        force_orphan: true
+        user_name: github-actions[bot]
+        user_email: github-actions[bot]@users.noreply.github.com


### PR DESCRIPTION
add missing cname and Git username and email
publish branch with only the latest commit,